### PR TITLE
Require sparse>=0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "numpy",
     "scipy",
-    "sparse",
+    "sparse>=0.12",
     "typing-extensions",
 ]
 classifiers = [


### PR DESCRIPTION
Previous versions don't have GCXS support, which this package relies on being there.