### PR TITLE
Include pytest.ini in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include pytest.ini


### PR DESCRIPTION
If we want to be able to run tests from sdist, pytest.ini needs to be included. For example needed for running tests in our conda-forge build.