### PR TITLE
Testcase fix for numpy 2.x

### DIFF
--- a/tests/test_sparseconverters.py
+++ b/tests/test_sparseconverters.py
@@ -47,8 +47,8 @@ def _mk_random(size, dtype='float32', array_backend=NUMPY):
         data = np.random.choice(choice, size=size).astype(dtype)
         coords2 = tuple(np.random.choice(range(c)) for c in size)
         coords10 = tuple(np.random.choice(range(c)) for c in size)
-        data[coords2] = np.random.choice(choice) * sum(size)
-        data[coords10] = np.random.choice(choice) * 10 * sum(size)
+        data[coords2] = (np.random.choice(choice) * sum(size)).astype(dtype)
+        data[coords10] = (np.random.choice(choice) * 10 * sum(size)).astype(dtype)
         data = for_backend(data, array_backend)
     else:
         raise ValueError(f"Don't understand array format {array_backend}.")

--- a/tests/test_sparseconverters.py
+++ b/tests/test_sparseconverters.py
@@ -157,10 +157,10 @@ def _scramble_coo(arr):
 
 
 @pytest.mark.parametrize(
-    'left', BACKENDS
+    'left', sorted(BACKENDS)
 )
 @pytest.mark.parametrize(
-    'right', BACKENDS
+    'right', sorted(BACKENDS)
 )
 @pytest.mark.parametrize(
     'dtype', [
@@ -400,10 +400,12 @@ def test_graceful_no_cupy():
         ((np.uint32, NUMPY, CUPY_SCIPY_COO, bool), np.float64),
         ((np.uint64, NUMPY, bool), np.uint64),
         ((CUPY_SCIPY_CSC, np.uint64, NUMPY, bool), np.float64),
-        (DENSE_BACKENDS.union(
+        (sorted(
+            DENSE_BACKENDS.union(
                 SPARSE_BACKENDS.intersection(CPU_BACKENDS), (CUPY_SCIPY_CSR, )
-            ), bool),
-        (BACKENDS, np.float32),
+            )
+        ), bool),
+        (sorted(BACKENDS), np.float32),
     ]
 )
 def test_result_type(args, expected):


### PR DESCRIPTION
Explicitly perform unsafe cast to fit choices into dest dtype. Tests w/ `cupy` on Linux pass.

Fixes #42. 