### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.7", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-14]
         exclude:
-          - python_version: "3.7"
-            os: macos-14
           - python_version: "3.9"
             os: macos-14
     runs-on: ${{ matrix.os }}
@@ -37,10 +35,12 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+      - name: Make virtualenv
+        run: python -m venv venv
       - name: Install tooling
-        run: pip install build
+        run: ./venv/bin/pip install build
       - name: Build wheel
-        run: python -m build --wheel --sdist
+        run: ./venv/bin/python -m build --wheel --sdist
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
   rev: v3.17.0
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py38-plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sparseconverter"
 description = "Converter matrix and type determination for a range of array formats, focusing on sparse arrays"
 license = {file = "LICENSE"}
 keywords = ["numpy", "scipy.sparse", "sparse", "array", "matrix", "cupy", "cupyx.scipy.sparse"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dynamic = ["version", "readme"]
 dependencies = [
     "numpy",
@@ -17,7 +17,6 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
We could also drop 3.8, as that is now officially EOL. Adding support for Python 3.13 depends on `numba` being ready.

I also updated the release action to use a `venv`, as newer Python/`pip` versions don't like global `pip install` very much.