### PR TITLE
Drop Python 3.8 and add Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-14]
         exclude:
           - python_version: "3.9"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project creates an unified API for all conversions between the supported fo
 dtype conversion, and using an efficient intermediate format for multi-step conversions.
 
 ## Features
-* Supports Python 3.8 - (at least) 3.12
+* Supports Python 3.9 - (at least) 3.13
 * Defines constants for format identifiers
 * Various sets to group formats into categories:
   * Dense vs sparse
@@ -80,7 +80,8 @@ and to perform efficient conversion to supported formats as needed.
 
 ### 0.5.0 (in development)
 
-* No changes yet
+* Drop support for Python 3.8 https://github.com/LiberTEM/sparseconverter/pull/61
+* Add support for Python 3.13 https://github.com/LiberTEM/sparseconverter/pull/61
 
 ### 0.4.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sparseconverter"
 description = "Converter matrix and type determination for a range of array formats, focusing on sparse arrays"
 license = {file = "LICENSE"}
 keywords = ["numpy", "scipy.sparse", "sparse", "array", "matrix", "cupy", "cupyx.scipy.sparse"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version", "readme"]
 dependencies = [
     "numpy",
@@ -17,11 +17,11 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 3 - Alpha",
 ]
 authors = [


### PR DESCRIPTION
Not tested on Python 3.13 with CuPy since not released yet for that version. Test against CuPy main branch from source is underway.

Closes #60 