### PR TITLE
Add SPDX classifier for the license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sparseconverter"
 description = "Converter matrix and type determination for a range of array formats, focusing on sparse arrays"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = ["numpy", "scipy.sparse", "sparse", "array", "matrix", "cupy", "cupyx.scipy.sparse"]
 requires-python = ">=3.9"
 dynamic = ["version", "readme"]


### PR DESCRIPTION
According to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/ nowadays you should have `license` and `license-files` metadata entries these days.