### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
   rev: v3.21.2
   hooks:
     - id: pyupgrade
-      args: ["--py38-plus"]
+      args: ["--py310-plus"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project creates an unified API for all conversions between the supported fo
 dtype conversion, and using an efficient intermediate format for multi-step conversions.
 
 ## Features
-* Supports Python 3.9 - (at least) 3.14
+* Supports Python 3.10 - (at least) 3.14
 * Defines constants for format identifiers
 * Various sets to group formats into categories:
   * Dense vs sparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Converter matrix and type determination for a range of array form
 license = "MIT"
 license-files = ["LICENSE"]
 keywords = ["numpy", "scipy.sparse", "sparse", "array", "matrix", "cupy", "cupyx.scipy.sparse"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version", "readme"]
 dependencies = [
     "numpy",
@@ -18,7 +18,6 @@ dependencies = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/sparseconverter/__init__.py
+++ b/src/sparseconverter/__init__.py
@@ -1,8 +1,9 @@
 from functools import partial, reduce, lru_cache
 import itertools
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, Optional, Tuple, Union, Hashable
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Union
+from collections.abc import Callable, Iterable, Hashable
+from typing import Literal
 
 import numpy as np
 import scipy.sparse as sp
@@ -257,7 +258,7 @@ def result_type(*args) -> np.dtype:
     return result_dtype
 
 
-def prod(shape: Tuple) -> int:
+def prod(shape: tuple) -> int:
     '''
     np.prod forced to np.int64 to prevent integer overflows
     '''
@@ -1237,10 +1238,10 @@ _cost = {
 
 # In order to support subclasses and not check all formats each time
 # we cache dynamically which type maps to which format code
-_type_cache: Dict[type, Optional[ArrayBackend]] = {}
+_type_cache: dict[type, ArrayBackend | None] = {}
 
 
-def get_backend(arr: ArrayT) -> Optional[ArrayBackend]:
+def get_backend(arr: ArrayT) -> ArrayBackend | None:
     '''
     Return the backend identifier for the given array
 
@@ -1275,7 +1276,7 @@ def get_backend(arr: ArrayT) -> Optional[ArrayBackend]:
 
 
 def get_converter(
-        source_backend: Optional[ArrayBackend], target_backend: Optional[ArrayBackend],
+        source_backend: ArrayBackend | None, target_backend: ArrayBackend | None,
         strict: bool = False
 ) -> Converter:
     '''
@@ -1292,7 +1293,7 @@ def get_converter(
 
 
 @lru_cache(maxsize=None)
-def _cheapest_pair(source_backends, target_backends) -> Tuple[ArrayBackend, ArrayBackend]:
+def _cheapest_pair(source_backends, target_backends) -> tuple[ArrayBackend, ArrayBackend]:
     '''
     Actual implementation for :func:`cheapest_pair`
     '''
@@ -1309,7 +1310,7 @@ def _cheapest_pair(source_backends, target_backends) -> Tuple[ArrayBackend, Arra
 
 def cheapest_pair(
         source_backends: Iterable[ArrayBackend], target_backends: Iterable[ArrayBackend]
-) -> Tuple[ArrayBackend, ArrayBackend]:
+) -> tuple[ArrayBackend, ArrayBackend]:
     '''
     Find an efficient converter from source to target.
 
@@ -1338,7 +1339,7 @@ def conversion_cost(source_backend: ArrayBackend, target_backend: ArrayBackend) 
     return _cost[key]
 
 
-def for_backend(arr: ArrayT, backend: Optional[ArrayBackend], strict: bool = True) -> ArrayT:
+def for_backend(arr: ArrayT, backend: ArrayBackend | None, strict: bool = True) -> ArrayT:
     '''
     Convert :code:`arr` to the specified backend
     '''
@@ -1376,7 +1377,7 @@ def check_shape(arr: ArrayT, shape: Iterable[int]) -> None:
             raise ValueError(f"Mismatching shape {arr.shape} vs {shape}, backend {backend}.")
 
 
-def get_device_class(backend: Optional[ArrayBackend]) -> DeviceClass:
+def get_device_class(backend: ArrayBackend | None) -> DeviceClass:
     '''
     Determine the device class associated with an array type
 


### PR DESCRIPTION
* Remove 3.9 from CI matrix
* Run pyupgrade to make use of new syntax